### PR TITLE
Instead of mapping out the various weight classes and then mimicking …

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,10 @@
 import React from 'react';
-import Text from './shared/components/text/Text';
 
 const App: React.FC = () => {
 
   return (
     <div className=''>
-      <Text text="This is extra small" size="xs" />
-      <Text text="This is large and bold" size="lg" weight="bold" />
-      <Text text="Italic and underlined" size="md" italic="italic" underline="underlined" />
-      <Text text="Mono font in 3xl" size="3x" font="mono" />
+      hello
     </div>
   );
 };

--- a/src/shared/components/text/Text.tsx
+++ b/src/shared/components/text/Text.tsx
@@ -1,13 +1,6 @@
 import React from 'react';
 import clsx from 'clsx';
-import type {
-  TextProps,
-  TextSize,
-  TextWeight,
-  TextItalic,
-  TextUnderline,
-  TextFont,
-} from './textTypes';
+import type { TextProps, TextSize, TextFont } from './textTypes';
 
 const sizeMap: Record<TextSize, string> = {
   xs: 'text-xs',
@@ -25,23 +18,6 @@ const sizeMap: Record<TextSize, string> = {
   '9x': 'text-9xl',
 };
 
-const weightMap: Record<TextWeight, string> = {
-  normal: 'font-normal',
-  medium: 'font-medium',
-  semibold: 'font-semibold',
-  bold: 'font-bold',
-};
-
-const italicMap: Record<TextItalic, string> = {
-  italic: 'italic',
-  notitalic: 'not-italic',
-};
-
-const underlineMap: Record<TextUnderline, string> = {
-  underlined: 'underline',
-  notunderlined: 'no-underline',
-};
-
 const fontMap: Record<TextFont, string> = {
   primary: 'font-primary',
   secondary: 'font-secondary',
@@ -53,18 +29,18 @@ const fontMap: Record<TextFont, string> = {
 const Text: React.FC<TextProps> = ({
   text,
   size,
-  weight = 'normal',
-  italic = 'notitalic',
-  underline = 'notunderlined',
+  bold = false,
+  italic = false,
+  underline = false,
   font = 'sans',
   color = 'text-gray-900',
   className = '',
 }) => {
   const classes = clsx(
     sizeMap[size],
-    weightMap[weight],
-    italicMap[italic],
-    underlineMap[underline],
+    bold && 'font-bold',
+    italic && 'italic',
+    underline && 'underline',
     fontMap[font],
     color,
     className

--- a/src/shared/components/text/textTypes.ts
+++ b/src/shared/components/text/textTypes.ts
@@ -1,15 +1,12 @@
 export type TextSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2x' | '3x' | '4x' | '5x' | '6x' | '7x' | '8x' | '9x';
-export type TextWeight = 'normal' | 'medium' | 'semibold' | 'bold';
-export type TextItalic = 'italic' | 'notitalic';
-export type TextUnderline = 'underlined' | 'notunderlined';
 export type TextFont = 'primary' | 'secondary' | 'sans' | 'serif' | 'mono';
 
 export interface TextProps {
   text: string;
   size: TextSize;
-  weight?: TextWeight;
-  italic?: TextItalic;
-  underline?: TextUnderline;
+  bold?: boolean;    
+  italic?: boolean;
+  underline?: boolean;
   font?: TextFont;
   color?: string;
   className?: string;


### PR DESCRIPTION
…those maps for italic and underline I made all three of those types in the textType file booleans so that they can be a simple true or false. For instances where more control is needed we can use the className prop provided for class blowoff