### PR TITLE
changing the param name from userId to userIdfrom Url so that we dont…

### DIFF
--- a/src/features/profile/Profile.tsx
+++ b/src/features/profile/Profile.tsx
@@ -72,12 +72,13 @@ const Profile: React.FC = () => {
 
               const updatedUser = {
                 ...profileUser,
+                userId: userIdFromUrl!, 
                 firstName: updatedData.firstName,
                 lastName: updatedData.lastName,
                 email: updatedData.email,
               };
               
-              dispatch(setAuthUser(updatedUser));
+              dispatch(setAuthUser(updatedUser)); 
 
               dispatch(preCloseModal());
               setProfileUser(updatedUser);


### PR DESCRIPTION
… run into duplicate naming conventions