### PR TITLE
negating the var we setup for is auth on the logged in drawer bc righ…

### DIFF
--- a/src/features/drawer/drawers/LoggedOutDrawerContent.tsx
+++ b/src/features/drawer/drawers/LoggedOutDrawerContent.tsx
@@ -73,7 +73,7 @@ const LoggedOutDrawerContent: React.FC = () => {
         entranceExit: {
           entranceAnimation: 'animate__fadeIn',
           exitAnimation: 'animate__fadeOut',
-          isEntering: isLoginHidden,
+          isEntering: !isLoginHidden,
         },
       }}
       >


### PR DESCRIPTION
…t now it fades out if we are not on the auth page. This will do the opposite